### PR TITLE
fix(docker): add missing ros2_medkit components and submodules

### DIFF
--- a/demos/turtlebot3_integration/Dockerfile
+++ b/demos/turtlebot3_integration/Dockerfile
@@ -32,6 +32,7 @@ RUN apt-get update && apt-get install -y \
     ros-jazzy-ament-cmake-gtest \
     ros-jazzy-ament-cmake-pytest \
     ros-jazzy-launch-testing-ament-cmake \
+    ros-jazzy-test-msgs \
     python3-colcon-common-extensions \
     python3-requests \
     nlohmann-json3-dev \
@@ -42,8 +43,11 @@ RUN apt-get update && apt-get install -y \
 
 # Clone ros2_medkit from GitHub
 WORKDIR ${COLCON_WS}/src
-RUN git clone --depth 1 https://github.com/selfpatch/ros2_medkit.git && \
-    mv ros2_medkit/src/ros2_medkit_gateway . && \
+RUN git clone --depth 1 --recurse-submodules https://github.com/selfpatch/ros2_medkit.git && \
+    mv ros2_medkit/src/ros2_medkit_gateway \
+       ros2_medkit/src/ros2_medkit_msgs \
+       ros2_medkit/src/ros2_medkit_serialization \
+       ros2_medkit/src/dynamic_message_introspection . && \
     rm -rf ros2_medkit
 
 # Copy demo package from local context (this repo)


### PR DESCRIPTION
## Description

This fix addresses a build breakage caused by https://github.com/selfpatch/ros2_medkit/pull/114, which introduced the dynamic_message_introspection submodule.

Note: The build was likely broken even before that PR, but the exact point of breakage was not traced back.

## Checklist

- [X] Tested locally
