### PR TITLE
fix(turtlebot3): resolve port conflict between CPU and NVIDIA profiles

### DIFF
--- a/demos/turtlebot3_integration/docker-compose.yml
+++ b/demos/turtlebot3_integration/docker-compose.yml
@@ -1,6 +1,8 @@
 services:
   # CPU-only version (default)
+  # Use with: docker compose --profile cpu up
   turtlebot3-demo:
+    profiles: ["cpu"]
     build:
       context: .
       dockerfile: Dockerfile

--- a/demos/turtlebot3_integration/stop-demo.sh
+++ b/demos/turtlebot3_integration/stop-demo.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# Stop TurtleBot3 + ros2_medkit Demo
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+echo "🛑 Stopping TurtleBot3 + ros2_medkit Demo"
+echo "=========================================="
+
+# Check for Docker
+if ! command -v docker &> /dev/null; then
+    echo "Error: Docker is not installed"
+    exit 1
+fi
+
+# Parse arguments
+REMOVE_VOLUMES=""
+REMOVE_IMAGES=""
+
+usage() {
+    echo "Usage: $0 [OPTIONS]"
+    echo ""
+    echo "Options:"
+    echo "  -v, --volumes    Remove named volumes"
+    echo "  --images         Remove images"
+    echo "  -h, --help       Show this help message"
+    echo ""
+    echo "Examples:"
+    echo "  $0               # Stop containers"
+    echo "  $0 --volumes     # Stop and remove volumes"
+    echo "  $0 --images      # Stop and remove images"
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -v|--volumes)
+            echo "Will remove named volumes"
+            REMOVE_VOLUMES="-v"
+            ;;
+        --images)
+            echo "Will remove images"
+            REMOVE_IMAGES="--rmi all"
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1"
+            usage
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+# Stop containers
+echo "Stopping containers..."
+if docker compose version &> /dev/null; then
+    # shellcheck disable=SC2086
+    docker compose down ${REMOVE_VOLUMES} ${REMOVE_IMAGES}
+else
+    # shellcheck disable=SC2086
+    docker-compose down ${REMOVE_VOLUMES} ${REMOVE_IMAGES}
+fi
+
+# Cleanup X11
+echo "Cleaning up X11 permissions..."
+xhost -local:docker 2>/dev/null || true
+
+echo ""
+echo "✅ Demo stopped successfully!"


### PR DESCRIPTION
## Description

- Add cpu/nvidia profiles to prevent simultaneous service startup
- Add stop-demo.sh script for clean shutdown with --volumes/--images options
- Add --update flag to pull latest images before running
- Add --attached flag for foreground mode (daemon mode is now default)
- Update README with daemon mode instructions and new scripts
- Add instructions for viewing logs and interacting with ROS 2 in containers

Fixes port 8080 conflict when running with --nvidia flag where both turtlebot3-demo and turtlebot3-demo-nvidia services tried to bind to the same port. Now --profile cpu (default) or --profile nvidia must be explicitly specified, ensuring mutual exclusivity.

Changes:
- docker-compose.yml: Add profiles=['cpu'] to default service
- run-demo.sh: Default to --profile cpu, add daemon mode with -d flag
- stop-demo.sh: New script for stopping containers with cleanup options
- README.md: Update Quick Start, add daemon mode docs, add stop script

## Related Issue

closes #18 

## Checklist

- [x] Tested locally
- [x] README updated (if needed)
