### PR TITLE
Fix missing ROS2MedkitCompat.cmake in turtlebot3_integration Dockerfile

### DIFF
--- a/demos/turtlebot3_integration/Dockerfile
+++ b/demos/turtlebot3_integration/Dockerfile
@@ -52,6 +52,7 @@ RUN git clone --depth 1 https://github.com/selfpatch/ros2_medkit.git && \
     mv ros2_medkit/src/ros2_medkit_fault_manager . && \
     mv ros2_medkit/src/ros2_medkit_fault_reporter . && \
     mv ros2_medkit/src/ros2_medkit_diagnostic_bridge . && \
+    mkdir -p ${COLCON_WS}/cmake && mv ros2_medkit/cmake/ROS2MedkitCompat.cmake ${COLCON_WS}/cmake/ && \
     rm -rf ros2_medkit
 
 # Copy demo package from local context (this repo)


### PR DESCRIPTION
## Description

Preserve `ROS2MedkitCompat.cmake` from the `ros2_medkit` clone before deleting it in the turtlebot3_integration Dockerfile. Without this, `colcon build` fails because `ros2_medkit_serialization` (and other packages) cannot resolve their `../../cmake/ROS2MedkitCompat.cmake` include path.

Same root cause as #28 / #29, but affecting a different demo.

The fix adds a single line to copy the shared CMake module to `${COLCON_WS}/cmake/` — the exact location the relative paths resolve to from packages under `${COLCON_WS}/src/`.

## Related Issue

Closes #30

## Checklist

- [x] Tested locally
- [x] README updated (if needed)