### PR TITLE
ci: trigger builds on ros2_medkit_updated dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
   repository_dispatch:
     types: [ros2_medkit_updated]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-24.04
@@ -40,12 +43,12 @@ jobs:
         run: |
           SHA="${{ github.event.client_payload.sha }}"
           RUN_URL="${{ github.event.client_payload.run_url }}"
-          echo "## Triggered by ros2_medkit" >> $GITHUB_STEP_SUMMARY
-          echo "- Commit: \`${SHA:-unknown}\`" >> $GITHUB_STEP_SUMMARY
+          echo "## Triggered by ros2_medkit" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Commit: \`${SHA:-unknown}\`" >> "$GITHUB_STEP_SUMMARY"
           if [ -n "$RUN_URL" ]; then
-            echo "- Run: [View triggering run]($RUN_URL)" >> $GITHUB_STEP_SUMMARY
+            echo "- Run: [View triggering run]($RUN_URL)" >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "- Run: (URL not provided)" >> $GITHUB_STEP_SUMMARY
+            echo "- Run: (URL not provided)" >> "$GITHUB_STEP_SUMMARY"
           fi
 
       - name: Checkout repository

--- a/demos/moveit_pick_place/Dockerfile
+++ b/demos/moveit_pick_place/Dockerfile
@@ -47,7 +47,7 @@ RUN git clone --depth 1 --branch ${ROS2_MEDKIT_REF} https://github.com/selfpatch
        ros2_medkit/src/ros2_medkit_fault_manager \
        ros2_medkit/src/ros2_medkit_fault_reporter \
        ros2_medkit/src/ros2_medkit_diagnostic_bridge . && \
-    mkdir -p ${COLCON_WS}/cmake && mv ros2_medkit/cmake/ROS2MedkitCompat.cmake ${COLCON_WS}/cmake/ && \
+    cp -r ros2_medkit/cmake ${COLCON_WS}/ && \
     rm -rf ros2_medkit
 
 # Copy demo package from local context

--- a/demos/sensor_diagnostics/Dockerfile
+++ b/demos/sensor_diagnostics/Dockerfile
@@ -32,7 +32,7 @@ RUN git clone --depth 1 https://github.com/selfpatch/ros2_medkit.git && \
     mv ros2_medkit/src/ros2_medkit_fault_manager . && \
     mv ros2_medkit/src/ros2_medkit_fault_reporter . && \
     mv ros2_medkit/src/ros2_medkit_diagnostic_bridge . && \
-    mkdir -p ${COLCON_WS}/cmake && mv ros2_medkit/cmake/ROS2MedkitCompat.cmake ${COLCON_WS}/cmake/ && \
+    cp -r ros2_medkit/cmake ${COLCON_WS}/ && \
     rm -rf ros2_medkit
 
 # Copy demo package

--- a/demos/turtlebot3_integration/Dockerfile
+++ b/demos/turtlebot3_integration/Dockerfile
@@ -52,7 +52,7 @@ RUN git clone --depth 1 https://github.com/selfpatch/ros2_medkit.git && \
     mv ros2_medkit/src/ros2_medkit_fault_manager . && \
     mv ros2_medkit/src/ros2_medkit_fault_reporter . && \
     mv ros2_medkit/src/ros2_medkit_diagnostic_bridge . && \
-    mkdir -p ${COLCON_WS}/cmake && mv ros2_medkit/cmake/ROS2MedkitCompat.cmake ${COLCON_WS}/cmake/ && \
+    cp -r ros2_medkit/cmake ${COLCON_WS}/ && \
     rm -rf ros2_medkit
 
 # Copy demo package from local context (this repo)


### PR DESCRIPTION
## Description

Adds a `repository_dispatch` trigger (`ros2_medkit_updated` event type) so `ros2_medkit` CI can notify `selfpatch_demos` to run a docker-build verification whenever ros2_medkit merges to main. Without this, breakages in ros2_medkit that affect the demo images go undetected until someone manually runs selfpatch_demos CI.

Also adds a `Show triggering source` step as the first step in the `docker-build` job. When triggered by `repository_dispatch`, it writes a step summary with the source commit SHA and a link to the ros2_medkit run - making it easy to trace a failed demo build back to the ros2_medkit change that caused it.

## Related Issue

closes selfpatch/ros2_medkit#224

## Checklist

- [x] Tested locally
- [x] README updated (if needed)