### PR TITLE
fix: use ros2_medkit_cmake package instead of copying cmake dir

### DIFF
--- a/demos/moveit_pick_place/Dockerfile
+++ b/demos/moveit_pick_place/Dockerfile
@@ -46,8 +46,8 @@ RUN git clone --depth 1 --branch ${ROS2_MEDKIT_REF} https://github.com/selfpatch
        ros2_medkit/src/ros2_medkit_serialization \
        ros2_medkit/src/ros2_medkit_fault_manager \
        ros2_medkit/src/ros2_medkit_fault_reporter \
-       ros2_medkit/src/ros2_medkit_diagnostic_bridge . && \
-    cp -r ros2_medkit/cmake ${COLCON_WS}/ && \
+       ros2_medkit/src/ros2_medkit_diagnostic_bridge \
+       ros2_medkit/src/ros2_medkit_cmake . && \
     rm -rf ros2_medkit
 
 # Copy demo package from local context

--- a/demos/sensor_diagnostics/Dockerfile
+++ b/demos/sensor_diagnostics/Dockerfile
@@ -32,7 +32,7 @@ RUN git clone --depth 1 https://github.com/selfpatch/ros2_medkit.git && \
     mv ros2_medkit/src/ros2_medkit_fault_manager . && \
     mv ros2_medkit/src/ros2_medkit_fault_reporter . && \
     mv ros2_medkit/src/ros2_medkit_diagnostic_bridge . && \
-    cp -r ros2_medkit/cmake ${COLCON_WS}/ && \
+    mv ros2_medkit/src/ros2_medkit_cmake . && \
     rm -rf ros2_medkit
 
 # Copy demo package

--- a/demos/turtlebot3_integration/Dockerfile
+++ b/demos/turtlebot3_integration/Dockerfile
@@ -52,7 +52,7 @@ RUN git clone --depth 1 https://github.com/selfpatch/ros2_medkit.git && \
     mv ros2_medkit/src/ros2_medkit_fault_manager . && \
     mv ros2_medkit/src/ros2_medkit_fault_reporter . && \
     mv ros2_medkit/src/ros2_medkit_diagnostic_bridge . && \
-    cp -r ros2_medkit/cmake ${COLCON_WS}/ && \
+    mv ros2_medkit/src/ros2_medkit_cmake . && \
     rm -rf ros2_medkit
 
 # Copy demo package from local context (this repo)


### PR DESCRIPTION
## Summary

Update all 3 demo Dockerfiles to use the new `ros2_medkit_cmake` ament package instead of manually copying the `cmake/` directory.

- closes #38

## Type

- [x] Bug fix

## Changes

Replace `cp -r ros2_medkit/cmake ${COLCON_WS}/` with `mv ros2_medkit/src/ros2_medkit_cmake .` in:
- `demos/sensor_diagnostics/Dockerfile`
- `demos/turtlebot3_integration/Dockerfile`
- `demos/moveit_pick_place/Dockerfile`

## Dependencies

Requires selfpatch/ros2_medkit#295 to be merged first.