### PR TITLE
feat: update all demos to gateway v0.4.0 with plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ to complete mobile robot integration:
 Both demos support:
 
 - REST API access via SOVD protocol
-- Web UI for visualization ([sovd_web_ui](https://github.com/selfpatch/sovd_web_ui))
+- Web UI for visualization ([ros2_medkit_web_ui](https://github.com/selfpatch/ros2_medkit_web_ui))
 - Fault injection and monitoring
 - Docker deployment for easy setup
 
@@ -189,7 +189,7 @@ CI runs all 3 demos in parallel - each job builds the Docker image, starts the c
 ## Related Projects
 
 - [ros2_medkit](https://github.com/selfpatch/ros2_medkit) — Core diagnostics library with SOVD-compliant gateway
-- [sovd_web_ui](https://github.com/selfpatch/sovd_web_ui) — Web-based visualization and control interface
+- [ros2_medkit_web_ui](https://github.com/selfpatch/ros2_medkit_web_ui) — Web-based visualization and control interface
 - [ros2_medkit_mcp](https://github.com/selfpatch/ros2_medkit_mcp) — MCP server for LLM integration
 - [ros2_medkit documentation](https://selfpatch.github.io/ros2_medkit/) — Full documentation and API reference
 

--- a/demos/moveit_pick_place/Dockerfile
+++ b/demos/moveit_pick_place/Dockerfile
@@ -31,6 +31,7 @@ RUN apt-get update && apt-get install -y \
     libcpp-httplib-dev \
     ros-jazzy-rosbag2-storage-mcap \
     ros-jazzy-foxglove-bridge \
+    libsystemd-dev \
     sqlite3 libsqlite3-dev git curl \
     && rm -rf /var/lib/apt/lists/*
 
@@ -41,13 +42,18 @@ RUN mkdir -p /var/lib/ros2_medkit/rosbags
 ARG ROS2_MEDKIT_REF=main
 WORKDIR ${COLCON_WS}/src
 RUN git clone --depth 1 --branch ${ROS2_MEDKIT_REF} https://github.com/selfpatch/ros2_medkit.git && \
+    mv ros2_medkit/src/ros2_medkit_cmake . && \
     mv ros2_medkit/src/ros2_medkit_gateway \
        ros2_medkit/src/ros2_medkit_msgs \
        ros2_medkit/src/ros2_medkit_serialization \
        ros2_medkit/src/ros2_medkit_fault_manager \
        ros2_medkit/src/ros2_medkit_fault_reporter \
-       ros2_medkit/src/ros2_medkit_diagnostic_bridge \
-       ros2_medkit/src/ros2_medkit_cmake . && \
+       ros2_medkit/src/ros2_medkit_diagnostic_bridge . && \
+    mv ros2_medkit/src/ros2_medkit_plugins/ros2_medkit_graph_provider . && \
+    mv ros2_medkit/src/ros2_medkit_discovery_plugins/ros2_medkit_beacon_common . && \
+    mv ros2_medkit/src/ros2_medkit_discovery_plugins/ros2_medkit_topic_beacon . && \
+    mv ros2_medkit/src/ros2_medkit_discovery_plugins/ros2_medkit_param_beacon . && \
+    mv ros2_medkit/src/ros2_medkit_discovery_plugins/ros2_medkit_linux_introspection . && \
     rm -rf ros2_medkit
 
 # Copy demo package from local context

--- a/demos/moveit_pick_place/README.md
+++ b/demos/moveit_pick_place/README.md
@@ -40,7 +40,7 @@ That's it! The script will:
 1. Build the Docker image (first run: ~15-20 min, ~7 GB)
 2. Set up X11 forwarding for Gazebo GUI
 3. Launch Panda robot in factory world + MoveIt 2 + ros2_medkit gateway
-4. Launch sovd_web_ui at http://localhost:3000
+4. Launch ros2_medkit_web_ui at http://localhost:3000
 
 **REST API:** http://localhost:8080/api/v1/
 **Web UI:** http://localhost:3000/
@@ -120,7 +120,7 @@ docker exec -it moveit_medkit_demo bash      # Shell into container
                                       │
                         ┌─────────────┼─────────────┐
                         │             │             │
-                   sovd_web_ui    curl/httpie    MCP Server
+                   ros2_medkit_web_ui    curl/httpie    MCP Server
                     :3000                        (LLM tools)
 ```
 
@@ -300,7 +300,7 @@ curl http://localhost:8080/api/v1/faults | jq '.items[] | {fault_code, severity_
 
 ## Web UI
 
-The sovd_web_ui container starts automatically at **http://localhost:3000**.
+The ros2_medkit_web_ui container starts automatically at **http://localhost:3000**.
 
 Connect it to the gateway at `http://localhost:8080` to browse:
 - Entity tree (Areas → Components → Apps)

--- a/demos/moveit_pick_place/config/medkit_params.yaml
+++ b/demos/moveit_pick_place/config/medkit_params.yaml
@@ -26,10 +26,8 @@ diagnostics:
         runtime:
           create_synthetic_components: false  # Manifest defines components
 
-      # Plugin configuration (paths set by launch file)
-      plugins: ["graph_provider", "procfs_introspection"]
-      plugins.graph_provider.path: ""
-      plugins.procfs_introspection.path: ""
+      # Plugin configuration (set by launch file when .so paths are resolved)
+      plugins: [""]
 
 # Fault Manager configuration (runs in root namespace)
 fault_manager:

--- a/demos/moveit_pick_place/config/medkit_params.yaml
+++ b/demos/moveit_pick_place/config/medkit_params.yaml
@@ -26,6 +26,11 @@ diagnostics:
         runtime:
           create_synthetic_components: false  # Manifest defines components
 
+      # Plugin configuration (paths set by launch file)
+      plugins: ["graph_provider", "procfs_introspection"]
+      plugins.graph_provider.path: ""
+      plugins.procfs_introspection.path: ""
+
 # Fault Manager configuration (runs in root namespace)
 fault_manager:
   ros__parameters:

--- a/demos/moveit_pick_place/docker-compose.yml
+++ b/demos/moveit_pick_place/docker-compose.yml
@@ -79,9 +79,9 @@ services:
                source /root/demo_ws/install/setup.bash &&
                ros2 launch moveit_medkit_demo demo.launch.py headless:=true"
 
-  # SOVD Web UI — pre-built from GHCR
-  sovd-web-ui:
-    image: ghcr.io/selfpatch/sovd_web_ui:latest
-    container_name: sovd_web_ui
+  # Web UI - pre-built from GHCR
+  medkit-web-ui:
+    image: ghcr.io/selfpatch/ros2_medkit_web_ui:latest
+    container_name: ros2_medkit_web_ui
     ports:
       - "3000:80"

--- a/demos/moveit_pick_place/launch/demo.launch.py
+++ b/demos/moveit_pick_place/launch/demo.launch.py
@@ -11,7 +11,9 @@ This launch file starts:
 
 import os
 
+from ament_index_python.packages import get_package_prefix
 from ament_index_python.packages import get_package_share_directory
+from ament_index_python.packages import PackageNotFoundError
 from launch import LaunchDescription
 from launch.actions import (
     DeclareLaunchArgument,
@@ -24,6 +26,18 @@ from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 
 
+def _resolve_plugin_path(package_name, lib_name):
+    """Resolve a gateway plugin .so path, returning empty string if not found."""
+    try:
+        prefix = get_package_prefix(package_name)
+        path = os.path.join(prefix, 'lib', package_name, f'lib{lib_name}.so')
+        if os.path.isfile(path):
+            return path
+    except PackageNotFoundError:
+        pass
+    return ''
+
+
 def generate_launch_description():
     # Get package share directories
     demo_pkg_dir = get_package_share_directory("moveit_medkit_demo")
@@ -34,6 +48,24 @@ def generate_launch_description():
     # Config file paths
     medkit_params_file = os.path.join(demo_pkg_dir, "config", "medkit_params.yaml")
     manifest_file = os.path.join(demo_pkg_dir, "config", "panda_manifest.yaml")
+
+    # Resolve plugin paths
+    graph_provider_path = _resolve_plugin_path(
+        'ros2_medkit_graph_provider', 'ros2_medkit_graph_provider_plugin')
+    procfs_plugin_path = _resolve_plugin_path(
+        'ros2_medkit_linux_introspection', 'procfs_introspection')
+
+    # Build plugin overrides - only include plugins that were found
+    plugin_overrides = {}
+    active_plugins = []
+    if graph_provider_path:
+        active_plugins.append('graph_provider')
+        plugin_overrides['plugins.graph_provider.path'] = graph_provider_path
+    if procfs_plugin_path:
+        active_plugins.append('procfs_introspection')
+        plugin_overrides['plugins.procfs_introspection.path'] = procfs_plugin_path
+    if active_plugins:
+        plugin_overrides['plugins'] = active_plugins
 
     # Launch configuration variables
     use_sim_time = LaunchConfiguration("use_sim_time", default="False")
@@ -128,6 +160,7 @@ def generate_launch_description():
                         "use_sim_time": use_sim_time,
                         "discovery.manifest_path": manifest_file,
                     },
+                    plugin_overrides,
                 ],
             ),
             # === Foxglove Bridge (WebSocket on port 8765) ===

--- a/demos/moveit_pick_place/launch/demo.launch.py
+++ b/demos/moveit_pick_place/launch/demo.launch.py
@@ -64,8 +64,7 @@ def generate_launch_description():
     if procfs_plugin_path:
         active_plugins.append('procfs_introspection')
         plugin_overrides['plugins.procfs_introspection.path'] = procfs_plugin_path
-    if active_plugins:
-        plugin_overrides['plugins'] = active_plugins
+    plugin_overrides['plugins'] = active_plugins
 
     # Launch configuration variables
     use_sim_time = LaunchConfiguration("use_sim_time", default="False")

--- a/demos/moveit_pick_place/launch/demo_gazebo.launch.py
+++ b/demos/moveit_pick_place/launch/demo_gazebo.launch.py
@@ -83,8 +83,7 @@ def generate_launch_description():
     if procfs_plugin_path:
         active_plugins.append('procfs_introspection')
         plugin_overrides['plugins.procfs_introspection.path'] = procfs_plugin_path
-    if active_plugins:
-        plugin_overrides['plugins'] = active_plugins
+    plugin_overrides['plugins'] = active_plugins
 
     # Factory world file path
     factory_world = os.path.join(

--- a/demos/moveit_pick_place/launch/demo_gazebo.launch.py
+++ b/demos/moveit_pick_place/launch/demo_gazebo.launch.py
@@ -21,7 +21,9 @@ import os
 
 import xacro
 import yaml
+from ament_index_python.packages import get_package_prefix
 from ament_index_python.packages import get_package_share_directory
+from ament_index_python.packages import PackageNotFoundError
 from launch import LaunchDescription
 from launch.actions import (
     DeclareLaunchArgument,
@@ -34,6 +36,18 @@ from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
+
+
+def _resolve_plugin_path(package_name, lib_name):
+    """Resolve a gateway plugin .so path, returning empty string if not found."""
+    try:
+        prefix = get_package_prefix(package_name)
+        path = os.path.join(prefix, 'lib', package_name, f'lib{lib_name}.so')
+        if os.path.isfile(path):
+            return path
+    except PackageNotFoundError:
+        pass
+    return ''
 
 
 def generate_launch_description():
@@ -53,6 +67,24 @@ def generate_launch_description():
     manifest_file = os.path.join(
         demo_pkg_dir, "config", "panda_manifest.yaml"
     )
+
+    # Resolve plugin paths
+    graph_provider_path = _resolve_plugin_path(
+        'ros2_medkit_graph_provider', 'ros2_medkit_graph_provider_plugin')
+    procfs_plugin_path = _resolve_plugin_path(
+        'ros2_medkit_linux_introspection', 'procfs_introspection')
+
+    # Build plugin overrides - only include plugins that were found
+    plugin_overrides = {}
+    active_plugins = []
+    if graph_provider_path:
+        active_plugins.append('graph_provider')
+        plugin_overrides['plugins.graph_provider.path'] = graph_provider_path
+    if procfs_plugin_path:
+        active_plugins.append('procfs_introspection')
+        plugin_overrides['plugins.procfs_introspection.path'] = procfs_plugin_path
+    if active_plugins:
+        plugin_overrides['plugins'] = active_plugins
 
     # Factory world file path
     factory_world = os.path.join(
@@ -472,6 +504,7 @@ def generate_launch_description():
                         "use_sim_time": True,
                         "discovery.manifest_path": manifest_file,
                     },
+                    plugin_overrides,
                 ],
             ),
             # ═════════════════════════════════════════════════════════

--- a/demos/sensor_diagnostics/Dockerfile
+++ b/demos/sensor_diagnostics/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update && apt-get install -y \
     python3-requests \
     nlohmann-json3-dev \
     libcpp-httplib-dev \
+    libsystemd-dev \
     sqlite3 \
     libsqlite3-dev \
     git \
@@ -23,16 +24,22 @@ RUN apt-get update && apt-get install -y \
     jq \
     && rm -rf /var/lib/apt/lists/*
 
-# Clone ros2_medkit from GitHub (gateway + dependencies)
+# Clone ros2_medkit from GitHub (gateway + dependencies + plugins)
+ARG ROS2_MEDKIT_REF=main
 WORKDIR ${COLCON_WS}/src
-RUN git clone --depth 1 https://github.com/selfpatch/ros2_medkit.git && \
+RUN git clone --depth 1 --branch ${ROS2_MEDKIT_REF} https://github.com/selfpatch/ros2_medkit.git && \
+    mv ros2_medkit/src/ros2_medkit_cmake . && \
     mv ros2_medkit/src/ros2_medkit_gateway . && \
     mv ros2_medkit/src/ros2_medkit_serialization . && \
     mv ros2_medkit/src/ros2_medkit_msgs . && \
     mv ros2_medkit/src/ros2_medkit_fault_manager . && \
     mv ros2_medkit/src/ros2_medkit_fault_reporter . && \
     mv ros2_medkit/src/ros2_medkit_diagnostic_bridge . && \
-    mv ros2_medkit/src/ros2_medkit_cmake . && \
+    mv ros2_medkit/src/ros2_medkit_plugins/ros2_medkit_graph_provider . && \
+    mv ros2_medkit/src/ros2_medkit_discovery_plugins/ros2_medkit_beacon_common . && \
+    mv ros2_medkit/src/ros2_medkit_discovery_plugins/ros2_medkit_topic_beacon . && \
+    mv ros2_medkit/src/ros2_medkit_discovery_plugins/ros2_medkit_param_beacon . && \
+    mv ros2_medkit/src/ros2_medkit_discovery_plugins/ros2_medkit_linux_introspection . && \
     rm -rf ros2_medkit
 
 # Copy demo package

--- a/demos/sensor_diagnostics/config/medkit_params.yaml
+++ b/demos/sensor_diagnostics/config/medkit_params.yaml
@@ -24,10 +24,8 @@ diagnostics:
         runtime:
           create_synthetic_components: false  # Manifest defines components
 
-      # Plugin configuration (paths set by launch file)
-      plugins: ["graph_provider", "procfs_introspection"]
-      plugins.graph_provider.path: ""
-      plugins.procfs_introspection.path: ""
+      # Plugin configuration (set by launch file when .so paths are resolved)
+      plugins: [""]
 
 # Fault Manager configuration (runs in root namespace)
 fault_manager:

--- a/demos/sensor_diagnostics/config/medkit_params.yaml
+++ b/demos/sensor_diagnostics/config/medkit_params.yaml
@@ -24,6 +24,11 @@ diagnostics:
         runtime:
           create_synthetic_components: false  # Manifest defines components
 
+      # Plugin configuration (paths set by launch file)
+      plugins: ["graph_provider", "procfs_introspection"]
+      plugins.graph_provider.path: ""
+      plugins.procfs_introspection.path: ""
+
 # Fault Manager configuration (runs in root namespace)
 fault_manager:
   ros__parameters:

--- a/demos/sensor_diagnostics/docker-compose.yml
+++ b/demos/sensor_diagnostics/docker-compose.yml
@@ -20,9 +20,9 @@ services:
                ros2 launch sensor_diagnostics_demo demo.launch.py"
 
   # Web UI for visualization (optional)
-  sovd-web-ui:
-    image: ghcr.io/selfpatch/sovd_web_ui:latest
-    container_name: sovd_web_ui
+  medkit-web-ui:
+    image: ghcr.io/selfpatch/ros2_medkit_web_ui:latest
+    container_name: ros2_medkit_web_ui
     ports:
       - "3000:80"
     depends_on:

--- a/demos/sensor_diagnostics/launch/demo.launch.py
+++ b/demos/sensor_diagnostics/launch/demo.launch.py
@@ -65,8 +65,7 @@ def generate_launch_description():
     if procfs_plugin_path:
         active_plugins.append('procfs_introspection')
         plugin_overrides['plugins.procfs_introspection.path'] = procfs_plugin_path
-    if active_plugins:
-        plugin_overrides['plugins'] = active_plugins
+    plugin_overrides['plugins'] = active_plugins
 
     # Launch arguments
     use_sim_time = LaunchConfiguration("use_sim_time", default="false")

--- a/demos/sensor_diagnostics/launch/demo.launch.py
+++ b/demos/sensor_diagnostics/launch/demo.launch.py
@@ -20,11 +20,25 @@ Namespace structure:
 
 import os
 
+from ament_index_python.packages import get_package_prefix
 from ament_index_python.packages import get_package_share_directory
+from ament_index_python.packages import PackageNotFoundError
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
+
+
+def _resolve_plugin_path(package_name, lib_name):
+    """Resolve a gateway plugin .so path, returning empty string if not found."""
+    try:
+        prefix = get_package_prefix(package_name)
+        path = os.path.join(prefix, 'lib', package_name, f'lib{lib_name}.so')
+        if os.path.isfile(path):
+            return path
+    except PackageNotFoundError:
+        pass
+    return ''
 
 
 def generate_launch_description():
@@ -35,6 +49,24 @@ def generate_launch_description():
     medkit_params_file = os.path.join(pkg_dir, "config", "medkit_params.yaml")
     sensor_params_file = os.path.join(pkg_dir, "config", "sensor_params.yaml")
     manifest_file = os.path.join(pkg_dir, "config", "sensor_manifest.yaml")
+
+    # Resolve plugin paths
+    graph_provider_path = _resolve_plugin_path(
+        'ros2_medkit_graph_provider', 'ros2_medkit_graph_provider_plugin')
+    procfs_plugin_path = _resolve_plugin_path(
+        'ros2_medkit_linux_introspection', 'procfs_introspection')
+
+    # Build plugin overrides - only include plugins that were found
+    plugin_overrides = {}
+    active_plugins = []
+    if graph_provider_path:
+        active_plugins.append('graph_provider')
+        plugin_overrides['plugins.graph_provider.path'] = graph_provider_path
+    if procfs_plugin_path:
+        active_plugins.append('procfs_introspection')
+        plugin_overrides['plugins.procfs_introspection.path'] = procfs_plugin_path
+    if active_plugins:
+        plugin_overrides['plugins'] = active_plugins
 
     # Launch arguments
     use_sim_time = LaunchConfiguration("use_sim_time", default="false")
@@ -120,6 +152,7 @@ def generate_launch_description():
                     medkit_params_file,
                     {"use_sim_time": use_sim_time},
                     {"discovery.manifest_path": manifest_file},
+                    plugin_overrides,
                 ],
             ),
             # ===== Fault Manager (at root namespace) =====

--- a/demos/turtlebot3_integration/Dockerfile
+++ b/demos/turtlebot3_integration/Dockerfile
@@ -37,22 +37,29 @@ RUN apt-get update && apt-get install -y \
     python3-requests \
     nlohmann-json3-dev \
     libcpp-httplib-dev \
+    libsystemd-dev \
     sqlite3 \
     libsqlite3-dev \
     git \
     curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Clone ros2_medkit from GitHub
+# Clone ros2_medkit from GitHub (gateway + dependencies + plugins)
+ARG ROS2_MEDKIT_REF=main
 WORKDIR ${COLCON_WS}/src
-RUN git clone --depth 1 https://github.com/selfpatch/ros2_medkit.git && \
+RUN git clone --depth 1 --branch ${ROS2_MEDKIT_REF} https://github.com/selfpatch/ros2_medkit.git && \
+    mv ros2_medkit/src/ros2_medkit_cmake . && \
     mv ros2_medkit/src/ros2_medkit_gateway . && \
     mv ros2_medkit/src/ros2_medkit_msgs . && \
     mv ros2_medkit/src/ros2_medkit_serialization . && \
     mv ros2_medkit/src/ros2_medkit_fault_manager . && \
     mv ros2_medkit/src/ros2_medkit_fault_reporter . && \
     mv ros2_medkit/src/ros2_medkit_diagnostic_bridge . && \
-    mv ros2_medkit/src/ros2_medkit_cmake . && \
+    mv ros2_medkit/src/ros2_medkit_plugins/ros2_medkit_graph_provider . && \
+    mv ros2_medkit/src/ros2_medkit_discovery_plugins/ros2_medkit_beacon_common . && \
+    mv ros2_medkit/src/ros2_medkit_discovery_plugins/ros2_medkit_topic_beacon . && \
+    mv ros2_medkit/src/ros2_medkit_discovery_plugins/ros2_medkit_param_beacon . && \
+    mv ros2_medkit/src/ros2_medkit_discovery_plugins/ros2_medkit_linux_introspection . && \
     rm -rf ros2_medkit
 
 # Copy demo package from local context (this repo)
@@ -66,7 +73,7 @@ WORKDIR ${COLCON_WS}
 RUN bash -c "source /opt/ros/jazzy/setup.bash && \
     rosdep update && \
     rosdep install --from-paths src --ignore-src -r -y && \
-    colcon build --symlink-install"
+    colcon build --symlink-install --cmake-args -DBUILD_TESTING=OFF"
 
 # Setup environment
 RUN echo "source /opt/ros/jazzy/setup.bash" >> ~/.bashrc && \

--- a/demos/turtlebot3_integration/README.md
+++ b/demos/turtlebot3_integration/README.md
@@ -18,7 +18,7 @@ This demo demonstrates:
 - **Rosbag snapshot capture** when faults are confirmed (MCAP format)
 - Querying robot data via **REST API**
 - Entity hierarchy: Areas → Components → Apps → Functions
-- Controlling the robot via sovd_web_ui
+- Controlling the robot via ros2_medkit_web_ui
 
 ## Prerequisites
 
@@ -40,7 +40,7 @@ That's it! The script will:
 1. Build the Docker images (first run takes ~5-10 min, downloads ~4GB)
 2. Setup X11 forwarding for Gazebo GUI
 3. Launch TurtleBot3 simulation + Nav2 + ros2_medkit gateway in **daemon mode** (background)
-4. Launch sovd_web_ui at <http://localhost:3000>
+4. Launch ros2_medkit_web_ui at <http://localhost:3000>
 
 **Note:** By default, the demo runs in **daemon mode** with **Gazebo GUI** enabled. This allows you to interact with ROS 2 while the demo is running.
 
@@ -119,7 +119,7 @@ docker compose --profile nvidia logs -f
 
 ### Via Web UI
 
-1. Connect to the gateway in sovd_web_ui
+1. Connect to the gateway in ros2_medkit_web_ui
 2. Find entity with `/cmd_vel` data
 3. Enter velocity command JSON (or use form with fields from schema):
 
@@ -449,7 +449,7 @@ curl -X DELETE http://localhost:8080/api/v1/faults
                                                  │
          ┌───────────────────────────────────────┼────────────────────┐
          ▼                    ▼                  ▼                    ▼
-   sovd_web_ui          curl/browser      External tools        MCP Server
+   ros2_medkit_web_ui          curl/browser      External tools        MCP Server
   (localhost:3000)                                          (ros2_medkit_mcp)
 ```
 

--- a/demos/turtlebot3_integration/config/medkit_params.yaml
+++ b/demos/turtlebot3_integration/config/medkit_params.yaml
@@ -25,10 +25,8 @@ diagnostics:
         runtime:
           create_synthetic_components: false  # Manifest defines components
 
-      # Plugin configuration (paths set by launch file)
-      plugins: ["graph_provider", "procfs_introspection"]
-      plugins.graph_provider.path: ""
-      plugins.procfs_introspection.path: ""
+      # Plugin configuration (set by launch file when .so paths are resolved)
+      plugins: [""]
 
 # Fault Manager configuration (runs in root namespace)
 fault_manager:

--- a/demos/turtlebot3_integration/config/medkit_params.yaml
+++ b/demos/turtlebot3_integration/config/medkit_params.yaml
@@ -25,6 +25,11 @@ diagnostics:
         runtime:
           create_synthetic_components: false  # Manifest defines components
 
+      # Plugin configuration (paths set by launch file)
+      plugins: ["graph_provider", "procfs_introspection"]
+      plugins.graph_provider.path: ""
+      plugins.procfs_introspection.path: ""
+
 # Fault Manager configuration (runs in root namespace)
 fault_manager:
   ros__parameters:

--- a/demos/turtlebot3_integration/docker-compose.yml
+++ b/demos/turtlebot3_integration/docker-compose.yml
@@ -82,8 +82,8 @@ services:
                export TURTLEBOT3_MODEL=burger &&
                ros2 launch turtlebot3_medkit_demo demo.launch.py headless:=true"
 
-  sovd-web-ui:
-    image: ghcr.io/selfpatch/sovd_web_ui:latest
-    container_name: sovd_web_ui
+  medkit-web-ui:
+    image: ghcr.io/selfpatch/ros2_medkit_web_ui:latest
+    container_name: ros2_medkit_web_ui
     ports:
       - "3000:80"

--- a/demos/turtlebot3_integration/launch/demo.launch.py
+++ b/demos/turtlebot3_integration/launch/demo.launch.py
@@ -10,7 +10,9 @@ This launch file demonstrates ros2_medkit's hierarchical discovery by:
 
 import os
 
+from ament_index_python.packages import get_package_prefix
 from ament_index_python.packages import get_package_share_directory
+from ament_index_python.packages import PackageNotFoundError
 from launch import LaunchDescription
 from launch.actions import (
     AppendEnvironmentVariable,
@@ -22,6 +24,18 @@ from launch.conditions import IfCondition, UnlessCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
+
+
+def _resolve_plugin_path(package_name, lib_name):
+    """Resolve a gateway plugin .so path, returning empty string if not found."""
+    try:
+        prefix = get_package_prefix(package_name)
+        path = os.path.join(prefix, 'lib', package_name, f'lib{lib_name}.so')
+        if os.path.isfile(path):
+            return path
+    except PackageNotFoundError:
+        pass
+    return ''
 
 
 def generate_launch_description():
@@ -36,6 +50,24 @@ def generate_launch_description():
     nav2_params_file = os.path.join(demo_pkg_dir, "config", "nav2_params.yaml")
     map_file = os.path.join(demo_pkg_dir, "config", "turtlebot3_world.yaml")
     manifest_file = os.path.join(demo_pkg_dir, "config", "turtlebot3_manifest.yaml")
+
+    # Resolve plugin paths
+    graph_provider_path = _resolve_plugin_path(
+        'ros2_medkit_graph_provider', 'ros2_medkit_graph_provider_plugin')
+    procfs_plugin_path = _resolve_plugin_path(
+        'ros2_medkit_linux_introspection', 'procfs_introspection')
+
+    # Build plugin overrides - only include plugins that were found
+    plugin_overrides = {}
+    active_plugins = []
+    if graph_provider_path:
+        active_plugins.append('graph_provider')
+        plugin_overrides['plugins.graph_provider.path'] = graph_provider_path
+    if procfs_plugin_path:
+        active_plugins.append('procfs_introspection')
+        plugin_overrides['plugins.procfs_introspection.path'] = procfs_plugin_path
+    if active_plugins:
+        plugin_overrides['plugins'] = active_plugins
 
     # Gazebo world file
     world_file = os.path.join(turtlebot3_gazebo_dir, "worlds", "turtlebot3_world.world")
@@ -167,6 +199,7 @@ def generate_launch_description():
                         "use_sim_time": use_sim_time,
                         "discovery.manifest_path": manifest_file,
                     },
+                    plugin_overrides,
                 ],
             ),
             # Launch anomaly detector to monitor navigation and report faults via fault manager

--- a/demos/turtlebot3_integration/launch/demo.launch.py
+++ b/demos/turtlebot3_integration/launch/demo.launch.py
@@ -66,8 +66,7 @@ def generate_launch_description():
     if procfs_plugin_path:
         active_plugins.append('procfs_introspection')
         plugin_overrides['plugins.procfs_introspection.path'] = procfs_plugin_path
-    if active_plugins:
-        plugin_overrides['plugins'] = active_plugins
+    plugin_overrides['plugins'] = active_plugins
 
     # Gazebo world file
     world_file = os.path.join(turtlebot3_gazebo_dir, "worlds", "turtlebot3_world.world")


### PR DESCRIPTION
## Description

Update all 3 demos to gateway v0.4.0 with new packages, plugin support, and fixes.

**Dockerfiles (all 3):**
- Add `ros2_medkit_cmake`, `ros2_medkit_graph_provider`, beacon plugins, linux introspection plugins
- Add `libsystemd-dev` for systemd introspection plugin
- Add `ARG ROS2_MEDKIT_REF=main` for pinnable builds (sensor, turtlebot)
- Add `-DBUILD_TESTING=OFF` to turtlebot3

**Config (all 3):**
- Fix broken discovery params: `discovery_mode` -> `discovery.mode`, `manifest_path` -> `discovery.manifest_path` (match current gateway nested namespace)
- Configure `graph_provider` and `procfs_introspection` plugins with dynamic path resolution in launch files

**Web UI rename (all 3):**
- Docker image: `ghcr.io/selfpatch/sovd_web_ui` -> `ghcr.io/selfpatch/ros2_medkit_web_ui`
- Service/container names updated in docker-compose.yml and READMEs

## Related Issue

closes #40

## Checklist

- [x] Tested locally
- [x] README updated (if needed)