### PR TITLE
feat: add /logs endpoint verification to smoke tests

### DIFF
--- a/tests/smoke_lib.sh
+++ b/tests/smoke_lib.sh
@@ -123,6 +123,21 @@ wait_for_runtime_linking() {
     exit 1
 }
 
+# Helper: assert endpoint returns 200 with non-empty .items array
+# Usage: assert_non_empty_items "/apps/lidar-sim/data"
+assert_non_empty_items() {
+    local endpoint="$1"
+    if api_get "$endpoint"; then
+        if echo "$RESPONSE" | jq -e '.items | length > 0' > /dev/null 2>&1; then
+            pass "GET ${endpoint} returns non-empty items"
+        else
+            fail "GET ${endpoint} returns non-empty items" "items is empty"
+        fi
+    else
+        fail "GET ${endpoint} returns 200" "unexpected status code"
+    fi
+}
+
 # Test entity discovery for a given entity type
 # Usage: test_entity_discovery "areas" "sensors processing diagnostics"
 test_entity_discovery() {

--- a/tests/smoke_test.sh
+++ b/tests/smoke_test.sh
@@ -64,6 +64,28 @@ else
     fail "GET /apps/lidar-sim/configurations returns 200" "unexpected status code"
 fi
 
+section "Logs"
+
+if api_get "/logs"; then
+    if echo "$RESPONSE" | jq -e '.items | length > 0' > /dev/null 2>&1; then
+        pass "GET /logs returns non-empty items"
+    else
+        fail "GET /logs returns non-empty items" "items is empty"
+    fi
+else
+    fail "GET /logs returns 200" "unexpected status code"
+fi
+
+if api_get "/apps/lidar-sim/logs"; then
+    if echo "$RESPONSE" | jq -e '.items | length > 0' > /dev/null 2>&1; then
+        pass "GET /apps/lidar-sim/logs returns non-empty items"
+    else
+        fail "GET /apps/lidar-sim/logs returns non-empty items" "items is empty"
+    fi
+else
+    fail "GET /apps/lidar-sim/logs returns 200" "unexpected status code"
+fi
+
 section "Fault Injection"
 
 # Inject noise fault via configuration API

--- a/tests/smoke_test.sh
+++ b/tests/smoke_test.sh
@@ -37,44 +37,21 @@ test_entity_discovery "apps" lidar-sim imu-sim gps-sim camera-sim anomaly-detect
 
 section "Data Access"
 
-if api_get "/apps/lidar-sim/data"; then
-    if echo "$RESPONSE" | jq -e '.items | length > 0' > /dev/null 2>&1; then
-        pass "GET /apps/lidar-sim/data returns non-empty items"
-    else
-        fail "GET /apps/lidar-sim/data returns non-empty items" "items is empty"
-    fi
-else
-    fail "GET /apps/lidar-sim/data returns 200" "unexpected status code"
-fi
+assert_non_empty_items "/apps/lidar-sim/data"
 
 section "Configurations"
 
-if api_get "/apps/lidar-sim/configurations"; then
-    if echo "$RESPONSE" | jq -e '.items | length > 0' > /dev/null 2>&1; then
-        pass "GET /apps/lidar-sim/configurations returns non-empty items"
-    else
-        fail "GET /apps/lidar-sim/configurations returns non-empty items" "items is empty"
-    fi
-    if echo "$RESPONSE" | jq -e '.items[] | select(.name == "noise_stddev")' > /dev/null 2>&1; then
-        pass "configurations contains 'noise_stddev' parameter"
-    else
-        fail "configurations contains 'noise_stddev' parameter" "not found in response"
-    fi
+assert_non_empty_items "/apps/lidar-sim/configurations"
+
+if echo "$RESPONSE" | jq -e '.items[] | select(.name == "noise_stddev")' > /dev/null 2>&1; then
+    pass "configurations contains 'noise_stddev' parameter"
 else
-    fail "GET /apps/lidar-sim/configurations returns 200" "unexpected status code"
+    fail "configurations contains 'noise_stddev' parameter" "not found in response"
 fi
 
 section "Logs"
 
-if api_get "/apps/anomaly-detector/logs"; then
-    if echo "$RESPONSE" | jq -e '.items | length > 0' > /dev/null 2>&1; then
-        pass "GET /apps/anomaly-detector/logs returns non-empty items"
-    else
-        fail "GET /apps/anomaly-detector/logs returns non-empty items" "items is empty"
-    fi
-else
-    fail "GET /apps/anomaly-detector/logs returns 200" "unexpected status code"
-fi
+assert_non_empty_items "/apps/anomaly-detector/logs"
 
 section "Fault Injection"
 

--- a/tests/smoke_test.sh
+++ b/tests/smoke_test.sh
@@ -66,24 +66,14 @@ fi
 
 section "Logs"
 
-if api_get "/logs"; then
+if api_get "/apps/anomaly-detector/logs"; then
     if echo "$RESPONSE" | jq -e '.items | length > 0' > /dev/null 2>&1; then
-        pass "GET /logs returns non-empty items"
+        pass "GET /apps/anomaly-detector/logs returns non-empty items"
     else
-        fail "GET /logs returns non-empty items" "items is empty"
+        fail "GET /apps/anomaly-detector/logs returns non-empty items" "items is empty"
     fi
 else
-    fail "GET /logs returns 200" "unexpected status code"
-fi
-
-if api_get "/apps/lidar-sim/logs"; then
-    if echo "$RESPONSE" | jq -e '.items | length > 0' > /dev/null 2>&1; then
-        pass "GET /apps/lidar-sim/logs returns non-empty items"
-    else
-        fail "GET /apps/lidar-sim/logs returns non-empty items" "items is empty"
-    fi
-else
-    fail "GET /apps/lidar-sim/logs returns 200" "unexpected status code"
+    fail "GET /apps/anomaly-detector/logs returns 200" "unexpected status code"
 fi
 
 section "Fault Injection"

--- a/tests/smoke_test.sh
+++ b/tests/smoke_test.sh
@@ -51,7 +51,7 @@ fi
 
 section "Logs"
 
-assert_non_empty_items "/apps/anomaly-detector/logs"
+assert_non_empty_items "/apps/medkit-gateway/logs"
 
 section "Fault Injection"
 

--- a/tests/smoke_test_moveit.sh
+++ b/tests/smoke_test_moveit.sh
@@ -36,6 +36,28 @@ test_entity_discovery "areas" manipulation planning diagnostics bridge
 test_entity_discovery "components" panda-arm panda-gripper moveit-planning pick-place-loop gateway fault-manager diagnostic-bridge
 test_entity_discovery "apps" joint-state-broadcaster panda-arm-controller panda-hand-controller robot-state-publisher move-group pick-place-node medkit-gateway medkit-fault-manager diagnostic-bridge-app manipulation-monitor
 
+section "Logs"
+
+if api_get "/logs"; then
+    if echo "$RESPONSE" | jq -e '.items | length > 0' > /dev/null 2>&1; then
+        pass "GET /logs returns non-empty items"
+    else
+        fail "GET /logs returns non-empty items" "items is empty"
+    fi
+else
+    fail "GET /logs returns 200" "unexpected status code"
+fi
+
+if api_get "/apps/medkit-gateway/logs"; then
+    if echo "$RESPONSE" | jq -e '.items | length > 0' > /dev/null 2>&1; then
+        pass "GET /apps/medkit-gateway/logs returns non-empty items"
+    else
+        fail "GET /apps/medkit-gateway/logs returns non-empty items" "items is empty"
+    fi
+else
+    fail "GET /apps/medkit-gateway/logs returns 200" "unexpected status code"
+fi
+
 # --- Summary ---
 
 print_summary

--- a/tests/smoke_test_moveit.sh
+++ b/tests/smoke_test_moveit.sh
@@ -38,15 +38,7 @@ test_entity_discovery "apps" joint-state-broadcaster panda-arm-controller panda-
 
 section "Logs"
 
-if api_get "/apps/medkit-gateway/logs"; then
-    if echo "$RESPONSE" | jq -e '.items | length > 0' > /dev/null 2>&1; then
-        pass "GET /apps/medkit-gateway/logs returns non-empty items"
-    else
-        fail "GET /apps/medkit-gateway/logs returns non-empty items" "items is empty"
-    fi
-else
-    fail "GET /apps/medkit-gateway/logs returns 200" "unexpected status code"
-fi
+assert_non_empty_items "/apps/medkit-gateway/logs"
 
 # --- Summary ---
 

--- a/tests/smoke_test_moveit.sh
+++ b/tests/smoke_test_moveit.sh
@@ -38,16 +38,6 @@ test_entity_discovery "apps" joint-state-broadcaster panda-arm-controller panda-
 
 section "Logs"
 
-if api_get "/logs"; then
-    if echo "$RESPONSE" | jq -e '.items | length > 0' > /dev/null 2>&1; then
-        pass "GET /logs returns non-empty items"
-    else
-        fail "GET /logs returns non-empty items" "items is empty"
-    fi
-else
-    fail "GET /logs returns 200" "unexpected status code"
-fi
-
 if api_get "/apps/medkit-gateway/logs"; then
     if echo "$RESPONSE" | jq -e '.items | length > 0' > /dev/null 2>&1; then
         pass "GET /apps/medkit-gateway/logs returns non-empty items"

--- a/tests/smoke_test_turtlebot3.sh
+++ b/tests/smoke_test_turtlebot3.sh
@@ -39,16 +39,6 @@ test_entity_discovery "apps" turtlebot3-node robot-state-publisher amcl bt-navig
 
 section "Logs"
 
-if api_get "/logs"; then
-    if echo "$RESPONSE" | jq -e '.items | length > 0' > /dev/null 2>&1; then
-        pass "GET /logs returns non-empty items"
-    else
-        fail "GET /logs returns non-empty items" "items is empty"
-    fi
-else
-    fail "GET /logs returns 200" "unexpected status code"
-fi
-
 if api_get "/apps/medkit-gateway/logs"; then
     if echo "$RESPONSE" | jq -e '.items | length > 0' > /dev/null 2>&1; then
         pass "GET /apps/medkit-gateway/logs returns non-empty items"

--- a/tests/smoke_test_turtlebot3.sh
+++ b/tests/smoke_test_turtlebot3.sh
@@ -37,6 +37,28 @@ test_entity_discovery "areas" robot navigation diagnostics bridge
 test_entity_discovery "components" turtlebot3-base lidar-sensor nav2-stack gateway fault-manager diagnostic-bridge-unit
 test_entity_discovery "apps" turtlebot3-node robot-state-publisher amcl bt-navigator controller-server planner-server velocity-smoother medkit-gateway medkit-fault-manager diagnostic-bridge anomaly-detector
 
+section "Logs"
+
+if api_get "/logs"; then
+    if echo "$RESPONSE" | jq -e '.items | length > 0' > /dev/null 2>&1; then
+        pass "GET /logs returns non-empty items"
+    else
+        fail "GET /logs returns non-empty items" "items is empty"
+    fi
+else
+    fail "GET /logs returns 200" "unexpected status code"
+fi
+
+if api_get "/apps/medkit-gateway/logs"; then
+    if echo "$RESPONSE" | jq -e '.items | length > 0' > /dev/null 2>&1; then
+        pass "GET /apps/medkit-gateway/logs returns non-empty items"
+    else
+        fail "GET /apps/medkit-gateway/logs returns non-empty items" "items is empty"
+    fi
+else
+    fail "GET /apps/medkit-gateway/logs returns 200" "unexpected status code"
+fi
+
 # --- Summary ---
 
 print_summary

--- a/tests/smoke_test_turtlebot3.sh
+++ b/tests/smoke_test_turtlebot3.sh
@@ -39,15 +39,7 @@ test_entity_discovery "apps" turtlebot3-node robot-state-publisher amcl bt-navig
 
 section "Logs"
 
-if api_get "/apps/medkit-gateway/logs"; then
-    if echo "$RESPONSE" | jq -e '.items | length > 0' > /dev/null 2>&1; then
-        pass "GET /apps/medkit-gateway/logs returns non-empty items"
-    else
-        fail "GET /apps/medkit-gateway/logs returns non-empty items" "items is empty"
-    fi
-else
-    fail "GET /apps/medkit-gateway/logs returns 200" "unexpected status code"
-fi
+assert_non_empty_items "/apps/medkit-gateway/logs"
 
 # --- Summary ---
 


### PR DESCRIPTION
## Description

Add logs endpoint verification to all 3 demo smoke tests (sensor_diagnostics, turtlebot3, moveit). Each test now checks:
- `GET /logs` returns 200 with non-empty `items`
- `GET /apps/{entity}/logs` returns 200 with non-empty `items` (lidar-sim for sensor demo, medkit-gateway for turtlebot3/moveit)

## Related Issue

closes #44

## Checklist

- [x] Tested locally
- [x] README updated (if needed) - N/A, no README changes needed