### PR TITLE
fix(demos): cap build parallelism to avoid gateway OOM

### DIFF
--- a/demos/moveit_pick_place/Dockerfile
+++ b/demos/moveit_pick_place/Dockerfile
@@ -76,7 +76,7 @@ RUN bash -c "source /opt/ros/jazzy/setup.bash && \
     rosdep update && \
     rosdep install --from-paths src --ignore-src -r -y || true" && \
     bash -c "source /opt/ros/jazzy/setup.bash && \
-    colcon build --symlink-install --cmake-args -DBUILD_TESTING=OFF"
+    MAKEFLAGS='-j 2' colcon build --executor sequential --symlink-install --cmake-args -DBUILD_TESTING=OFF"
 
 # Setup environment
 RUN echo "source /opt/ros/jazzy/setup.bash" >> ~/.bashrc && \

--- a/demos/multi_ecu_aggregation/Dockerfile
+++ b/demos/multi_ecu_aggregation/Dockerfile
@@ -57,7 +57,7 @@ RUN bash -c "source /opt/ros/jazzy/setup.bash && \
     rosdep update && \
     rosdep install --from-paths src --ignore-src -r -y \
       --skip-keys='ament_cmake_clang_format ament_cmake_clang_tidy test_msgs example_interfaces sqlite3' && \
-    colcon build --symlink-install --cmake-args -DBUILD_TESTING=OFF"
+    MAKEFLAGS='-j 2' colcon build --executor sequential --symlink-install --cmake-args -DBUILD_TESTING=OFF"
 
 # Setup environment
 RUN echo "source /opt/ros/jazzy/setup.bash" >> ~/.bashrc && \

--- a/demos/sensor_diagnostics/Dockerfile
+++ b/demos/sensor_diagnostics/Dockerfile
@@ -58,7 +58,7 @@ RUN bash -c "source /opt/ros/jazzy/setup.bash && \
     rosdep update && \
     rosdep install --from-paths src --ignore-src -r -y \
       --skip-keys='ament_cmake_clang_format ament_cmake_clang_tidy test_msgs example_interfaces sqlite3' && \
-    colcon build --symlink-install --cmake-args -DBUILD_TESTING=OFF"
+    MAKEFLAGS='-j 2' colcon build --executor sequential --symlink-install --cmake-args -DBUILD_TESTING=OFF"
 
 # Setup environment
 RUN echo "source /opt/ros/jazzy/setup.bash" >> ~/.bashrc && \

--- a/demos/turtlebot3_integration/Dockerfile
+++ b/demos/turtlebot3_integration/Dockerfile
@@ -78,7 +78,7 @@ WORKDIR ${COLCON_WS}
 RUN bash -c "source /opt/ros/jazzy/setup.bash && \
     rosdep update && \
     rosdep install --from-paths src --ignore-src -r -y && \
-    colcon build --symlink-install --cmake-args -DBUILD_TESTING=OFF"
+    MAKEFLAGS='-j 2' colcon build --executor sequential --symlink-install --cmake-args -DBUILD_TESTING=OFF"
 
 # Setup environment
 RUN echo "source /opt/ros/jazzy/setup.bash" >> ~/.bashrc && \


### PR DESCRIPTION
## Problem

Docker builds for the demos fail intermittently with:

```
c++: fatal error: Killed signal terminated program cc1plus
... ResourceExhausted: cannot allocate memory
```

The build always dies in `ros2_medkit_gateway`. It is not a compile error and not architecture-specific (`diagnostic_bridge` and the other packages build cleanly). It is an out-of-memory kill of the compiler.

## Root cause

The gateway has a few heavily-templated translation units (HTTP handlers) that peak at ~1.6 GB RSS each when compiling. colcon/make compiled them in parallel, one job per CPU core, so total peak scaled with core count. On many-core or RAM-limited Docker hosts (e.g. Docker Desktop), several heavy units overlap and exceed the memory limit, so `cc1plus` is OOM-killed. Whether a given machine succeeds depended on core count and scheduling timing, so it was flaky (passed on 8-core/8 GB, failed on a higher-core host even at 12 GB).

## Fix

Limit build parallelism in the four demos that build the gateway from source: `--executor sequential` (one package at a time) + `MAKEFLAGS='-j 2'` (at most two compilers at once). Peak drops to ~3.2 GB, making the build deterministic across hosts.

`manymove_industrial` already has its own parallelism knob (`MANYMOVE_COLCON_WORKERS`) and is left unchanged.

## Verification

Built the gateway from `main` inside a container hard-capped at `--memory=6g --memory-swap=6g`:

```
Finished <<< ros2_medkit_gateway [2min 19s]
Summary: 4 packages finished
```

Passes at 6 GB with margin; the previous unbounded build was OOM-killed under the same cap.