### PR TITLE
fix(demos): build new gateway bridge packages from source

### DIFF
--- a/demos/moveit_pick_place/Dockerfile
+++ b/demos/moveit_pick_place/Dockerfile
@@ -44,6 +44,8 @@ WORKDIR ${COLCON_WS}/src
 RUN git clone --depth 1 --branch ${ROS2_MEDKIT_REF} https://github.com/selfpatch/ros2_medkit.git && \
     mv ros2_medkit/src/ros2_medkit_cmake . && \
     mv ros2_medkit/src/ros2_medkit_gateway \
+       ros2_medkit/src/ros2_medkit_log_bridge \
+       ros2_medkit/src/ros2_medkit_action_status_bridge \
        ros2_medkit/src/ros2_medkit_msgs \
        ros2_medkit/src/ros2_medkit_serialization \
        ros2_medkit/src/ros2_medkit_fault_manager \

--- a/demos/multi_ecu_aggregation/Dockerfile
+++ b/demos/multi_ecu_aggregation/Dockerfile
@@ -33,6 +33,8 @@ WORKDIR ${COLCON_WS}/src
 RUN git clone --depth 1 --branch ${ROS2_MEDKIT_REF} https://github.com/selfpatch/ros2_medkit.git && \
     mv ros2_medkit/src/ros2_medkit_cmake . && \
     mv ros2_medkit/src/ros2_medkit_gateway . && \
+    mv ros2_medkit/src/ros2_medkit_log_bridge . && \
+    mv ros2_medkit/src/ros2_medkit_action_status_bridge . && \
     mv ros2_medkit/src/ros2_medkit_serialization . && \
     mv ros2_medkit/src/ros2_medkit_msgs . && \
     mv ros2_medkit/src/ros2_medkit_fault_manager . && \

--- a/demos/sensor_diagnostics/Dockerfile
+++ b/demos/sensor_diagnostics/Dockerfile
@@ -30,6 +30,8 @@ WORKDIR ${COLCON_WS}/src
 RUN git clone --depth 1 --branch ${ROS2_MEDKIT_REF} https://github.com/selfpatch/ros2_medkit.git && \
     mv ros2_medkit/src/ros2_medkit_cmake . && \
     mv ros2_medkit/src/ros2_medkit_gateway . && \
+    mv ros2_medkit/src/ros2_medkit_log_bridge . && \
+    mv ros2_medkit/src/ros2_medkit_action_status_bridge . && \
     mv ros2_medkit/src/ros2_medkit_serialization . && \
     mv ros2_medkit/src/ros2_medkit_msgs . && \
     mv ros2_medkit/src/ros2_medkit_fault_manager . && \

--- a/demos/turtlebot3_integration/Dockerfile
+++ b/demos/turtlebot3_integration/Dockerfile
@@ -51,6 +51,8 @@ WORKDIR ${COLCON_WS}/src
 RUN git clone --depth 1 --branch ${ROS2_MEDKIT_REF} https://github.com/selfpatch/ros2_medkit.git && \
     mv ros2_medkit/src/ros2_medkit_cmake . && \
     mv ros2_medkit/src/ros2_medkit_gateway . && \
+    mv ros2_medkit/src/ros2_medkit_log_bridge . && \
+    mv ros2_medkit/src/ros2_medkit_action_status_bridge . && \
     mv ros2_medkit/src/ros2_medkit_msgs . && \
     mv ros2_medkit/src/ros2_medkit_serialization . && \
     mv ros2_medkit/src/ros2_medkit_fault_manager . && \


### PR DESCRIPTION
## Description

`ros2_medkit_gateway` now declares two runtime dependencies, `ros2_medkit_log_bridge` and `ros2_medkit_action_status_bridge`. The demo Dockerfiles clone ros2_medkit and move a fixed subset of packages into the colcon workspace; these two were not in the subset, so rosdep tried to install them from apt and failed:

    E: Unable to locate package ros-jazzy-ros2-medkit-action-status-bridge

They are not in the jazzy apt repo, so all demo build jobs failed (turtlebot3, sensor_diagnostics, multi_ecu_aggregation; moveit on a clean build).

This adds both packages to the clone/mv list in the four demo Dockerfiles so they build from the cloned source like the other gateway packages.

## Related Issue

closes #68

## Checklist

- [x] Tested locally (built the sensor_diagnostics image against gateway main: rosdep resolves, both bridges and the gateway compile, image completes)
- [ ] README updated (not needed)
